### PR TITLE
Remove `jupyter-bundlerextension` entry point 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,6 @@ build:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - jupyter-server = jupyter_server.serverapp:main
-    - jupyter-bundlerextension = jupyter_server.bundlerextensions:main
 
 requirements:
   build:


### PR DESCRIPTION
When running constructor with `jupyter_server` and `notebook` in the specs, there is the following error:
```
Error: File 'bin/jupyter-bundlerextension' found in multiple packages: jupyter_server-1.2.2-py38h578d9bd_0.tar.bz2, notebook-6.2.0-py38h578d9bd_0.tar.bz2
```

Indeed, `jupyter-bundlerextension` entry point has been removed in https://github.com/jupyter-server/jupyter_server/pull/194 and there it should be removed in this feedstock too.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->.
