### PR TITLE
add floor on nbformat

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
@@ -29,7 +29,7 @@ requirements:
     - jupyter_client >=6.1.1
     - jupyter_core >=4.6.0
     - nbconvert
-    - nbformat >= 5.2.0
+    - nbformat >=5.2.0
     - packaging
     - prometheus_client
     - python >=3.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - jupyter_client >=6.1.1
     - jupyter_core >=4.6.0
     - nbconvert
-    - nbformat
+    - nbformat >= 5.2.0
     - packaging
     - prometheus_client
     - python >=3.7


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

## Proposed changes

* adds a floor of `nbformat>=5.2.0`

## Impact

Without these changes, it's possible to get into a situation with incompatible `jupyter_server` and `nbformat` versions, which prevents creation of notebooks (at least in Jupyter Lab).

## Reproducible example

<details><summary>output of 'conda info'</summary>

```text
     active environment : None
       user config file : /Users/James.Lamb/.condarc
 populated config files : 
          conda version : 4.12.0
    conda-build version : not installed
         python version : 3.8.5.final.0
       virtual packages : __osx=10.16=0
                          __unix=0=0
                          __archspec=1=x86_64
       base environment : /Users/James.Lamb/miniconda3  (writable)
      conda av data dir : /Users/James.Lamb/miniconda3/etc/conda
  conda av metadata url : None
           channel URLs : https://repo.anaconda.com/pkgs/main/osx-64
                          https://repo.anaconda.com/pkgs/main/noarch
                          https://repo.anaconda.com/pkgs/r/osx-64
                          https://repo.anaconda.com/pkgs/r/noarch
          package cache : /Users/James.Lamb/miniconda3/pkgs
                          /Users/James.Lamb/.conda/pkgs
       envs directories : /Users/James.Lamb/miniconda3/envs
                          /Users/James.Lamb/.conda/envs
               platform : osx-64
             user-agent : conda/4.12.0 requests/2.27.1 CPython/3.8.5 Darwin/20.5.0 OSX/10.16
                UID:GID : 504:20
             netrc file : None
           offline mode : False
```

</details>

First, create an environment with older versions of `jupyter_server` and `nbformat`

```shell
conda config --add channels conda-forge
conda config --set channel_priority strict
conda create --name example --yes \
    python=3.9 \
    nbformat==5.1.3 \
    jupyterlab==3.3.2 \
    jupyter_server==1.13.5
```

Start up Jupyter Lab, then create and save notebook.

```shell
mkdir -p ${HOME}/sandbox/jserver-example
cd ${HOME}/sandbox/jserver-example
source activate example
jupyter lab
```

<img width="500" alt="image" src="https://user-images.githubusercontent.com/7608904/159397318-cdb1f9f2-4ac0-4d93-a26d-30466e5c8c10.png">

Exit Jupyter Lab, then update ONLY `jupyter_server` in that conda environment.

```shell
conda update --name example --yes \
    jupyter_server
```

Next, run JupyterLab and try to create and save a notebook.

```shell
jupyter lab
```

On loading, you'll see an error from the existing notebook.

> **File Load Error for test.ipynb**
Unreadable Notebook: /Users/James.Lamb/sandbox/jserver-example/test.ipynb TypeError("__init__() got an unexpected keyword argument 'capture_validation_error'")

<img width="500" alt="image" src="https://user-images.githubusercontent.com/7608904/159397505-0db875d9-208e-4d8e-9c95-ce1264985553.png">

Try to create a *new* notebook in Jupyter Lab, you'll see a different error.

> **Error**
Unexpected error while saving file: Untitled.ipynb [Errno 2] No such file or directory: '/Users/James.Lamb/sandbox/jserver-example/.~Untitled.ipynb' -> '/Users/James.Lamb/sandbox/jserver-example/Untitled.ipynb'

<img width="500" alt="image" src="https://user-images.githubusercontent.com/7608904/159397602-9bcd4494-12e5-4fc8-beaf-4d68153dfce6.png">

Exit Jupyter Lab, then update to a newer `nbformat` in the environment.

```shell
conda update --name example --yes \
    nbformat
```

> The following packages will be UPDATED:
> nbformat                               5.1.3-pyhd8ed1ab_0 --> 5.2.0-pyhd8ed1ab_0

Run Jupyter Lab again...now notebooks load successfully and it's possible to create and save new ones.

## Notes

Today, I updated a conda environment with `jupyter_server` in it, and found that I got the newest `jupyter_server` (v1.15.6) but that my `nbformat` version wasn't upgraded (I had 5.1.3, and the newest is 5.2.0).

As a result, I wasn't able to create notebooks in Jupyter Lab...saw the following error when creating a new notebook

> **File Load Error for explore.ipynb**
Unreadable Notebook: /usr/local/src/notebooks/explore.ipynb TypeError("__init__() got an unexpected keyword argument 'capture_validation_error'")

After some investigation, I determined that this is because `jupyter_server>=1.15.0` is incompatible with `nbformat<5.2.0`.

* https://github.com/jupyter-server/jupyter_server/pull/724 passes argument `capture_validation_error` through to `nbformat.write()`
* prior to https://github.com/jupyter/nbformat/pull/249, `nbformat.write()` didn't accept that keyword argument, and instead passed it through `**kwargs` until it eventually got passed to `json.dumps()`, which generates the error above
* `jupyter_server`'s package metadata for PyPI contains a floor of `nbformat>=5.2.0`: https://github.com/jupyter-server/jupyter_server/blob/619fd23aef7064f23e49e36e43b99beff97a7d5b/setup.cfg#L37

## Notes for Reviewers

Thanks for your time and consideration!